### PR TITLE
Update L1_processPointClouds.R

### DIFF
--- a/scripts/L1_processPointClouds.R
+++ b/scripts/L1_processPointClouds.R
@@ -61,7 +61,7 @@ clusterEvalQ(cl, library(terra))
 clusterEvalQ(cl, library(lidR))
 clusterExport(cl, c("gridInfo", "catObj", "dirPath"))
 parSapply(cl, 1:nrow(gridInfo), standardizePC, gridInfo, catObj, overlap=30, 
-           ROI=bciBorder, dirPath, type="align")
+           dirPath, type="align", ROI=bciBorder)
 stopCluster(cl)
 
 ##-------------------------------------------------------##


### PR DESCRIPTION
Minor workflow changes:
- Clip standardized point clouds by island border to avoid different areas of lake points in different years.
- Remove .bin files after Cloud Compare ICP
- Organize Cloud Compare ICP transformation matrices in their own folder